### PR TITLE
Updates to allow persistent disks to mount in Pangeo GCP.

### DIFF
--- a/dask_kubernetes/kubernetes/dask_notebook.yaml
+++ b/dask_kubernetes/kubernetes/dask_notebook.yaml
@@ -33,14 +33,14 @@ spec:
             runAsUser: 1000
           workingDir: /work
           volumeMounts:
-            - mountPath: /data/newman-met-ensemble
-              name: newman-met-ensemble
+            - mountPath: /data/gfdl-cm2-6
+              name: gfdl-cm2-6
               readOnly: true
       volumes:
-        - name: newman-met-ensemble
+        - name: gfdl-cm2-6
           # This GCE PD must already exist.
           gcePersistentDisk:
-            pdName: newman-met-ensemble
+            pdName: gfdl-cm2-6
             fsType: ext4
             readOnly: true
       nodeSelector:

--- a/dask_kubernetes/kubernetes/dask_scheduler.yaml
+++ b/dask_kubernetes/kubernetes/dask_scheduler.yaml
@@ -34,14 +34,14 @@ spec:
               memory: {{scheduler.memory}}
           imagePullPolicy: Always
           volumeMounts:
-            - mountPath: /data/newman-met-ensemble
-              name: newman-met-ensemble
+            - mountPath: /data/gfdl-cm2-6
+              name: gfdl-cm2-6
               readOnly: true
       volumes:
-        - name: newman-met-ensemble
+        - name: gfdl-cm2-6
           # This GCE PD must already exist.
           gcePersistentDisk:
-            pdName: newman-met-ensemble
+            pdName: gfdl-cm2-6
             fsType: ext4
             readOnly: true
       nodeSelector:

--- a/dask_kubernetes/kubernetes/dask_workers.yaml
+++ b/dask_kubernetes/kubernetes/dask_workers.yaml
@@ -31,13 +31,13 @@ spec:
             runAsUser: 1000
           workingDir: /work
           volumeMounts:
-            - mountPath: /data/newman-met-ensemble
-              name: newman-met-ensemble
+            - mountPath: /data/gfdl-cm2-6
+              name: gfdl-cm2-6
               readOnly: true
       volumes:
-        - name: newman-met-ensemble
+        - name: gfdl-cm2-6
           # This GCE PD must already exist.
           gcePersistentDisk:
-            pdName: newman-met-ensemble
+            pdName: gfdl-cm2-6
             fsType: ext4
             readOnly: true

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: pangeo
+name: pangeo-dask-k8s
 channels:
   - conda-forge
 dependencies:


### PR DESCRIPTION
The issue was that the newman-met-ensemble had a partition.  Kubernetes expects the volume to not be partioned.